### PR TITLE
chore: replace deprecated set-output command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
             - name: "Set composer cache directory"
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: "Cache composer"
               uses: actions/cache@v2.1.2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,7 @@ jobs:
 
             - name: "Set composer cache directory"
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: "Cache composer"
               uses: actions/cache@v2.1.2


### PR DESCRIPTION
https://github.com/eclipse/che/issues/21993