### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: php-symfony
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-16_26_39](https://github.com/che-samples/php-symfony/assets/1271546/5e865403-6817-4170-8568-b34f44ae914c)

Related issue: https://github.com/eclipse/che/issues/21985

